### PR TITLE
web: Add POST /check endpoint for immediate clustermonitor check

### DIFF
--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -7,6 +7,7 @@ This file is under the Apache License, Version 2.0.
 See the file `LICENSE` for details.
 """
 from pglookout.webserver import WebServer
+from queue import Queue
 import random
 import requests
 import time
@@ -20,11 +21,18 @@ def test_webserver():
         "hello": 123,
     }
     base_url = "http://127.0.0.1:{}".format(config["http_port"])
-    web = WebServer(config=config, cluster_state=cluster_state)
+    cluster_monitor_check_queue = Queue()
+
+    web = WebServer(config=config, cluster_state=cluster_state, cluster_monitor_check_queue=cluster_monitor_check_queue)
     try:
         web.start()
         time.sleep(1)
         result = requests.get("{}/state.json".format(base_url)).json()
         assert result == cluster_state
+
+        result = requests.post("{}/check".format(base_url))
+        assert result.status_code == 204
+        res = cluster_monitor_check_queue.get(timeout=1.0)
+        assert res == "request from webserver"
     finally:
         web.close()


### PR DESCRIPTION
This is to allow HTTP based requests to make an immediate request
to check the cluster status and to do an immediate failover decision.