### PR TITLE
Allow marking a node as "known to be gone"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -288,6 +288,12 @@ over_warning_limit_command and to create a warning file.
 
 Shell command to execute in case the node has deemed itself in need of promotion
 
+``known_gone_nodes`` (default ``[]``)
+
+Lists nodes that are explicitly known to have left the cluster. If old master is
+removed in a controlled manner it should be added to this list to ensure there's
+no extra delay when making promotion decision.
+
 ``never_promote_these_nodes`` (default ``[]``)
 
 Lists the nodes that will never be considered valid for promotion. As

--- a/pglookout.json
+++ b/pglookout.json
@@ -4,6 +4,7 @@
     "failover_sleep_time": 0.0,
     "http_address": "",
     "http_port": 15000,
+    "known_gone_nodes": [],
     "log_level": "DEBUG",
     "max_failover_replication_time_lag": 120.0,
     "never_promote_these_nodes": [],


### PR DESCRIPTION
If current master disappeared from configuration promotion was not
performed until a timeout was exceeded, presumably to guard against
situations where node goes missing from config due to some fluke and
is very soon put back into configuration.

In case of controlled removal of old master the master can be known to
be gone and not coming back for sure. Allow indicating such situation
in pglookout configuration so that gracefully terminated old master can
be replaced immediately.