### PR TITLE
Ensure master WAL position is returned correctly

### DIFF
--- a/pglookout/cluster_monitor.py
+++ b/pglookout/cluster_monitor.py
@@ -197,6 +197,9 @@ class ClusterMonitor(Thread):
             self.log.warning("%s (%s) %s %s", ex.__class__.__name__, str(ex).strip(), phase, instance)
             db_conn.close()
             self.db_conns[instance] = None
+            # Return "no connection" result in case of any error. If we get an error for master server after the initial
+            # query we'd end up returning completely invalid value for master's current position
+            return result
 
         result.update(self._parse_status_query_result(f_result))
         return result


### PR DESCRIPTION
For the master node we want to track the current position instead of the
most recent replication position. If fetching replication position
succeeded but the second query for getting current position failed, the
master's last replication position was returned instead of it's current
position. This could make standbys to possibly seem to be ahead of the
master even when that was not the case.