### PR TITLE
pglookout.spec: support building on Fedora 31

### DIFF
--- a/pglookout.spec
+++ b/pglookout.spec
@@ -7,8 +7,8 @@ License:        ASL 2.0
 Source0:        pglookout-rpm-src.tar
 Obsoletes:      python3-pglookout
 Requires:       python3-psycopg2, python3-requests, python3-setuptools, systemd-python3, systemd
+BuildRequires:  python3-psycopg2, python3-requests, python3-setuptools, systemd-python3, systemd
 BuildRequires:  python3-pytest, python3-pylint
-BuildRequires:  %{requires}
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
Fedora 31 comes with an updated rpmbuild that is more picky about what
it will accept. The %{requires} macro is no longer accepted in the
BuildRequires field.