### PR TITLE
Issue 53: stopping of primary when it becomes isolated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -368,11 +368,19 @@ The minimum number of nodes the master should be replicating with.
 If the number of replicating nodes falls below this mark, then 
 too_few_replicating_nodes_command is called if defined.
 
+``too_few_replicating_nodes_timeout`` (default: ``60.0``)
+
+How long to allow the number of replicating nodes to be less than
+minimum_replicating_nodes, before too_few_replicating_nodes_command 
+is called.
+
 ``too_few_replicating_nodes_command`` (default: disabled)
 
 When the number of replicating nodes on the master falls 
-below minimum_replicating_nodes, this command is called.
-Note that it will be called repeatedly as long as this condition continues.
+below minimum_replicating_nodes for longer than 
+too_few_replicating_nodes_timeout seconds, this command is called.
+Note that it will be called repeatedly as long as this condition continues
+and the master is running.
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -362,6 +362,18 @@ Metrics sending follows the `Telegraf spec`_.
 
 .. _`Telegraf spec`: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd
 
+``minimum_replicating_nodes`` (default: disabled)
+
+The minimum number of nodes the master should be replicating with.
+If the number of replicating nodes falls below this mark, then 
+too_few_replicating_nodes_command is called if defined.
+
+``too_few_replicating_nodes_command`` (default: disabled)
+
+When the number of replicating nodes on the master falls 
+below minimum_replicating_nodes, this command is called.
+Note that it will be called repeatedly as long as this condition continues.
+
 
 License
 =======


### PR DESCRIPTION
resolves #53 
Create two new config keys:
  * minimum_replicating_nodes (default: disabled)
    The minimum number of nodes the master should be replicating with.
    If the number of replicating nodes falls below this mark, then
    too_few_replicating_nodes_command is called if defined.
  * too_few_replicating_nodes_command (default: disabled)
    When the number of replicating nodes on the master falls
    below minimum_replicating_nodes, this command is called.
    Note that it will be called repeatedly as long as this condition continues.

The query that is run on the master node is enhanced to count the number
of records in pg_stat_replication; this is stored in in the field
pg_master_replication_connections.

The too_few_replicating_nodes_command can simply stop the master, or do
more checking first, or whatever. Because the script is called repeatedly,
if you want to stop the master, you should first test whether it is running,
to avoid pg_ctl giving errors.