### PR TITLE
a new key is added to the config: poll_observers_on_warning_only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,11 @@ pglookout observer processes.  Observers are processes that don't take any
 actions, but simply give a third party viewpoint on the state of the
 cluster.  Useful especially during net splits.
 
+``poll_observers_on_warning_only`` (default ``False``)
+
+this allows observers to be polled only when replication lag is over
+``warning_replication_time_lag``
+
 ``http_address`` (default ``""``)
 
 HTTP webserver address, by default pglookout binds to all interfaces.


### PR DESCRIPTION
this key allows the polling of observers only when pglookout notices
that it is in warning mode.
This is useful when the observer is a single entity observing many
different clusters. And in that case pglookout needs to make sure
the db_poll has happened at-least once to retrieve data from observers.

In pglookout's producer-consumer architecture, consumer thread makes
the decision based on polled data. The consumer relies on timeout along
with ping from producer. Because of timeouts the consumer might
accidentally rely on stale data from the producer. And one way to
indicate staleness is when consumer is in warning mode and even though
observers are configured their polling information is not
available/updated.

Once the option is set to True, observers will be polled and in warning
state only. Therefore the consumer needs to make sure it is consuming
data newer than utcnow)(trakced in in observer_state_newer_than). And
waits for latest observer data relying on the fetch_time of the
observer. However this wait period is limited to db_poll_interval.

This in combination allows consumer to have atleast one
round before moving from warning->critical and not act like a trigger
(direct from normal to critical). This trigger is seen when the node is
back from a being heavily loaded and replication was stalled.

On a subsequent successful poll-monitor loop if replication begins
normally consumer should be able to detect it.