### PR TITLE
clear the decision queue

### DIFF
--- a/pglookout/pglookout.py
+++ b/pglookout/pglookout.py
@@ -649,6 +649,12 @@ class PgLookout:
                 self.stats.unexpected_exception(ex, where="main_loop_writer_cluster_state")
             try:
                 self.failover_decision_queue.get(timeout=float(self.config.get("replication_state_check_interval", 5.0)))
+                q = self.failover_decision_queue
+                while not q.empty():
+                    try:
+                        q.get(False)
+                    except Empty:
+                        continue
                 self.log.info("Immediate failover check completed")
             except Empty:
                 pass


### PR DESCRIPTION
to make sure consumer threads is not looping unnecessarily. This can
happen if the node is loaded and consumer thread has remain unscheduled