### PR TITLE
Fix test for pylint 2.6.0

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -75,7 +75,7 @@ class TestPG:
         subprocess.check_call(argv)
 
     def run_pg(self):
-        self.pg = subprocess.Popen([  # pylint: disable=consider-using-with
+        self.pg = subprocess.Popen([  # pylint: disable=bad-option-value,consider-using-with
             os.path.join(self.pgbin, "postgres"),
             "-D", self.pgdata, "-k", self.pgdata,
             "-p", "5432", "-c", "listen_addresses=",


### PR DESCRIPTION
Because pylint 2.6.0 does not recognise "consider-using-with", triggers
"bad-option-value" error
> E0012: Bad option value 'consider-using-with' (bad-option-value)

Allow bad-option-value during the transition