### PR TITLE
enable codecov for pglookout repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get install -y postgresql-${{ matrix.pg-version }}
           # Setup common python dependencies
           python -m pip install --upgrade pip
-          pip install --upgrade pytest mock
+          pip install --upgrade pytest mock pytest-cov
           pip install -e .
 
       - id: unittest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,4 +71,9 @@ jobs:
           pip install -e .
 
       - id: unittest
-        run: make unittest
+        run: make coverage
+
+      - id: upload-codecov
+        uses: codecov/codecov-action@v2
+        with:
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 build/
 pglookout.egg-info/
 .coverage
+coverage.xml
 /pglookout/version.py
 
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ pylint: $(generated)
 	$(PYTHON) -m pylint --rcfile .pylintrc $(PYLINT_DIRS)
 
 coverage:
-	$(PYTHON) -m pytest $(PYTEST_ARG) --cov-report term-missing --cov-report xml:coverage.xml \
-		--cov pglookout test/
+	$(PYTHON) -m pytest $(PYTEST_ARG) --cov-report term-missing --cov-branch \
+		--cov-report xml:coverage.xml --cov pglookout test/
 
 clean:
 	$(RM) -r *.egg-info/ build/ dist/

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ pylint: $(generated)
 	$(PYTHON) -m pylint --rcfile .pylintrc $(PYLINT_DIRS)
 
 coverage:
-	$(PYTHON) -m pytest $(PYTEST_ARG) --cov-report term-missing --cov pglookout test/
+	$(PYTHON) -m pytest $(PYTEST_ARG) --cov-report term-missing --cov-report xml:coverage.xml \
+		--cov pglookout test/
 
 clean:
 	$(RM) -r *.egg-info/ build/ dist/

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,10 @@
-pglookout
-=========
+pglookout |BuildStatus| |Codecov|_
+==================================
+
+.. |BuildStatus| image:: https://github.com/aiven/pglookout/actions/workflows/build.yml/badge.svg?branch=main
+.. _BuildStatus: https://github.com/aiven/pglookout/actions
+.. |Codecov| image:: https://codecov.io/gh/aiven/pglookout/branch/main/graph/badge.svg?token=nLr7M7hvCx
+.. _Codecov: https://codecov.io/gh/aiven/pglookout
 
 pglookout is a PostgreSQL® replication monitoring and failover daemon.
 pglookout monitors PG database nodes and their replication status and acts

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+        # advanced settings
+        if_ci_failed: error  # success, failure, error, ignore
+        only_pulls: false
+        if_not_found: failure


### PR DESCRIPTION
The goal of this PR is to enable codecov in this repository.
- Start generating coverage reports
- Upload reports in CI
- Add badge with codecov

Add the following simple settings as a start point that we can improve later on:
```
        threshold: 0%
        # advanced settings
        if_ci_failed: error  # success, failure, error, ignore
        only_pulls: false
        if_not_found: failure
```

Some follow ups:
- improve the dependencies (instead passing hard coded in build.yml)
- check if we really need to keep running pg version from 9.6 <> 14 and python version from 3.6 <> 3.9