### PR TITLE
add missing dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,12 @@ build-dep-fed:
 		python3-devel python3-pytest python3-pylint \
 		python3-mock python3-psycopg2 \
 		python3-requests rpm-build systemd-python3 \
-		python3-flake8 python3-pytest-cov
+		python3-flake8 python3-pytest-cov python3-packaging
 
 build-dep-deb:
 	sudo apt-get install \
 		build-essential devscripts dh-systemd \
-		python3-all python3-setuptools python3-psycopg2 python3-requests
+		python3-all python3-setuptools python3-psycopg2 python3-requests \
+		python3-packaging
 
 .PHONY: rpm

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Homepage: https://github.com/aiven/pglookout
 Package: pglookout
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends},
- python3-psycopg2 (>= 2.4.0-1), python3-requests (>= 1.2.0-1)
+ python3-packaging, python3-psycopg2 (>= 2.4.0-1), python3-requests (>= 1.2.0-1)
 Description: pglookout is a PostgreSQL replication monitoring and failover daemon.
  pglookout monitors PG database nodes and their replication status and acts
  according to that status, for example calling a predefined failover command

--- a/pglookout.spec
+++ b/pglookout.spec
@@ -6,8 +6,8 @@ Summary:        PostgreSQL replication monitoring and failover daemon
 License:        ASL 2.0
 Source0:        pglookout-rpm-src.tar
 Obsoletes:      python3-pglookout
-Requires:       python3-psycopg2, python3-requests, python3-setuptools, systemd-python3, systemd
-BuildRequires:  python3-psycopg2, python3-requests, python3-setuptools, systemd-python3, systemd
+Requires:       python3-packaging, python3-psycopg2, python3-requests, python3-setuptools, systemd-python3, systemd
+BuildRequires:  python3-packaging, python3-psycopg2, python3-requests, python3-setuptools, systemd-python3, systemd
 BuildRequires:  python3-pytest, python3-pylint
 BuildArch:      noarch
 

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -28,10 +28,10 @@ def test_webserver():
     try:
         web.start()
         time.sleep(1)
-        result = requests.get(f"{base_url}/state.json").json()
+        result = requests.get(f"{base_url}/state.json", timeout=5).json()
         assert result == cluster_state
 
-        result = requests.post(f"{base_url}/check")
+        result = requests.post(f"{base_url}/check", timeout=5)
         assert result.status_code == 204
         res = cluster_monitor_check_queue.get(timeout=1.0)
         assert res == "request from webserver"


### PR DESCRIPTION
07c85331e replaced the use of distutils.version (which is deprecated)
with the officially recommended packaging package. Declare packaging as
a dependency.