### PR TITLE
Keep cache of replication slots states [BF-1513]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage.xml
 /pglookout/version.py
 
 .idea/
+rpm/

--- a/pglookout/cluster_monitor.py
+++ b/pglookout/cluster_monitor.py
@@ -9,7 +9,7 @@ See the file `LICENSE` for details.
 """
 
 from . import logutil
-from .common import get_iso_timestamp, parse_iso_datetime
+from .common import get_iso_timestamp, parse_iso_datetime, convert_xlog_location_to_offset
 from .pgutil import mask_connection_info
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from dataclasses import dataclass, asdict
@@ -25,6 +25,9 @@ import psycopg2
 import requests
 import select
 import time
+
+
+REPLICATION_SLOTS_CACHE_SIZE = 5
 
 
 class PglookoutTimeout(Exception):
@@ -65,7 +68,8 @@ def wait_select(conn, timeout=5.0):
 
 class ClusterMonitor(Thread):
     def __init__(self, config, cluster_state, observer_state, create_alert_file, cluster_monitor_check_queue,
-                 failover_decision_queue, is_replication_lag_over_warning_limit, stats):
+                 failover_decision_queue, is_replication_lag_over_warning_limit, stats, replication_slots_cache,
+                 replication_slots_cache_size: int = REPLICATION_SLOTS_CACHE_SIZE):
         """Thread which collects cluster state.
 
         Basically a loop which tries to connect to each cluster member and
@@ -78,6 +82,8 @@ class ClusterMonitor(Thread):
         self.running = True
         self.cluster_state = cluster_state
         self.observer_state = observer_state
+        self.replication_slots_cache = replication_slots_cache
+        self.replication_slots_cache_size = replication_slots_cache_size
         self.config = config
         self.create_alert_file = create_alert_file
         self.db_conns = {}
@@ -294,6 +300,54 @@ class ClusterMonitor(Thread):
             self.cluster_state[instance].update(result)
         else:
             self.cluster_state[instance] = result
+
+        repl_slots_info = self.cluster_state[instance].get("replication_slots")
+        if repl_slots_info:
+            # This is the master, add new state to the cache
+            for repl_slot in repl_slots_info:
+                slot_states = self.replication_slots_cache.get(repl_slot["slot_name"], [])
+                slot_state_already_cached = next(
+                    (slot_state for slot_state in slot_states
+                        if slot_state["confirmed_flush_lsn"] == repl_slot["confirmed_flush_lsn"]), None
+                )
+                # If cache is full or client did not flush yet, or we have this LSN already - skip it
+                if len(slot_states) >= self.replication_slots_cache_size or repl_slot["confirmed_flush_lsn"] is None or \
+                        slot_state_already_cached:
+                    continue
+                self.replication_slots_cache.setdefault(repl_slot["slot_name"], [])
+                self.replication_slots_cache[repl_slot["slot_name"]].append(repl_slot)
+
+        # Invalidate old states and truncate cache if needed, we assume that if there is at least one node which
+        # has already advanced to the LSN position from the slot, then this slot position is usable
+        latest_received_offset = None
+        for node_state in self.cluster_state.values():
+            xlog_location = node_state.get("pg_last_xlog_receive_location")
+            if xlog_location:
+                if latest_received_offset is None:
+                    latest_received_offset = convert_xlog_location_to_offset(xlog_location)
+                else:
+                    latest_received_offset = max(latest_received_offset, convert_xlog_location_to_offset(xlog_location))
+
+        if latest_received_offset is not None:
+            for slot_states in self.replication_slots_cache.values():
+                latest_usable_state = None
+                for idx, slot_state in enumerate(slot_states):
+                    if convert_xlog_location_to_offset(slot_state["confirmed_flush_lsn"]) >= latest_received_offset:
+                        latest_usable_state = idx - 1
+                        break
+
+                if latest_usable_state is None:
+                    # All slots are old enough, just leave the last one
+                    if slot_states:
+                        slot_states[0:-1] = []
+                    continue
+
+                if latest_usable_state <= 0:
+                    # Nothing to purge
+                    continue
+
+                # Keep everything from the latest usable one
+                slot_states[0:latest_usable_state] = []
 
         # record the first time we saw replication happen from the master
         if result.get("pg_last_xlog_receive_location"):

--- a/pglookout/common.py
+++ b/pglookout/common.py
@@ -4,8 +4,12 @@ pglookout - common utility functions
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
+from typing import Dict, Any
 import datetime
 import re
+
+
+JsonObject = Dict[str, Any]
 
 
 def convert_xlog_location_to_offset(wal_location):

--- a/test/test_cluster_monitor.py
+++ b/test/test_cluster_monitor.py
@@ -4,7 +4,7 @@ pglookout
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
-
+from pglookout.common import JsonObject
 from .conftest import TestPG
 from contextlib import closing
 from datetime import datetime, timedelta
@@ -14,6 +14,7 @@ from pglookout import statsd
 from pglookout.cluster_monitor import ClusterMonitor
 from psycopg2.extras import RealDictCursor
 from queue import Queue
+from typing import Callable, Optional, Tuple
 
 import base64
 import psycopg2
@@ -66,7 +67,8 @@ def test_main_loop(db):
         cluster_monitor_check_queue=cluster_monitor_check_queue,
         failover_decision_queue=failover_decision_queue,
         stats=statsd.StatsClient(host=None),
-        is_replication_lag_over_warning_limit=lambda: False
+        is_replication_lag_over_warning_limit=lambda: False,
+        replication_slots_cache={}
     )
     cm.main_monitoring_loop(requested_check=True)
 
@@ -120,7 +122,8 @@ def test_fetch_replication_slot_info(db: TestPG) -> None:
         cluster_monitor_check_queue=cluster_monitor_check_queue,
         failover_decision_queue=failover_decision_queue,
         stats=statsd.StatsClient(host=None),
-        is_replication_lag_over_warning_limit=lambda: False
+        is_replication_lag_over_warning_limit=lambda: False,
+        replication_slots_cache={}
     )
     cm.main_monitoring_loop(requested_check=True)
 
@@ -138,3 +141,148 @@ def test_fetch_replication_slot_info(db: TestPG) -> None:
             assert b"\0" in base64.b64decode(slot.state_data)
 
             cursor.execute("SELECT pg_drop_replication_slot('testslot1')")
+
+
+def repl_slot1_data(slot_lsn: str) -> JsonObject:
+    return {
+        "slot_name": "test_slot_v1",
+        "plugin": "wal2json",
+        "slot_type": "logical",
+        "database": "defaultdb",
+        "catalog_xmin": "7565",
+        "restart_lsn": "0/2F0021B0",
+        "confirmed_flush_lsn": slot_lsn,
+        "state_data": "oRwFAcg9zQUCAAAAuAAAAHRlc3Rfc2xvdF92MwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdQAAAAAAAAAAAAACNHQAAsCEALwAAAAAAAAAAAAAAAOgh\n"
+                      "AC8AAAAA6CEALwAAAAAAd2FsMmpzb24AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    }
+
+
+def repl_slot2_data(slot_lsn: str) -> JsonObject:
+    return {
+        "slot_name": "test_slot_v2",
+        "plugin": "wal2json",
+        "slot_type": "logical",
+        "database": "defaultdb",
+        "catalog_xmin": "7565",
+        "restart_lsn": "0/2F0021B0",
+        "confirmed_flush_lsn": slot_lsn,
+        "state_data": "oRwFAXYIR6MCAAAAuAAAAHRlc3Rfc2xvdF92MgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdQAAAAAAAAAAAAACNHQAACBkALwAAAAAAAAAAAAAAAEAZ\n"
+                      "AC8AAAAAQBkALwAAAAAAdGVzdF9kZWNvZGluZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    }
+
+
+def create_query_cluster_member_state(
+        slot1_lsn: Optional[str], slot2_lsn: Optional[str], standby_lsn: str
+) -> Callable[[str, Tuple[str, bytes]], JsonObject]:
+    def query_cluster_member_state(instance: str, _: Tuple[str, bytes]) -> JsonObject:
+        # Master
+        if instance == "test1db":
+            return {
+                "fetch_time": "2022-10-13T07:11:07.087062Z",
+                "connection": True,
+                "db_time": "2022-10-13T07:11:07.087648Z",
+                "pg_is_in_recovery": False,
+                "pg_last_xact_replay_timestamp": None,
+                "pg_last_xlog_receive_location": None,
+                "pg_last_xlog_replay_location": "1/E000548",
+                "replication_slots": [repl_slot1_data(slot1_lsn), repl_slot2_data(slot2_lsn)]
+            }
+        return {
+            "fetch_time": "2022-10-13T07:11:07.087439Z",
+            "connection": True,
+            "db_time": "2022-10-13T07:11:07.087604Z",
+            "pg_is_in_recovery": True,
+            "pg_last_xact_replay_timestamp": "2022-10-13T07:11:05.085952Z",
+            "pg_last_xlog_receive_location": standby_lsn,
+            "pg_last_xlog_replay_location": "1/E000548",
+            "replication_time_lag": 2.001652,
+            "min_replication_time_lag": 0.007882
+        }
+    return query_cluster_member_state
+
+
+def test_update_cluster_member_state_replication_slots_cache(db: TestPG) -> None:
+    if version.parse(db.pgver) < version.parse("10"):
+        pytest.skip(f"unsupported pg version: {db.pgver}")
+
+    config = {
+        "remote_conns": {
+            "test1db": db.connection_string("testuser"),
+            "test2db": db.connection_string("otheruser"),
+        },
+        "observers": {"local": "URL"},
+        "poll_observers_on_warning_only": True
+    }
+    cluster_state = {}
+    observer_state = {}
+
+    def create_alert_file(arg) -> None:
+        raise Exception(arg)
+
+    cluster_monitor_check_queue = Queue()
+    failover_decision_queue = Queue()
+
+    cm = ClusterMonitor(
+        config=config,
+        cluster_state=cluster_state,
+        observer_state=observer_state,
+        create_alert_file=create_alert_file,
+        cluster_monitor_check_queue=cluster_monitor_check_queue,
+        failover_decision_queue=failover_decision_queue,
+        stats=statsd.StatsClient(host=None),
+        is_replication_lag_over_warning_limit=lambda: False,
+        replication_slots_cache={}
+    )
+
+    # Only first slot state should be added, as the second one does not have anything flushed
+    with patch.object(cm, "_query_cluster_member_state", create_query_cluster_member_state(
+        slot1_lsn="0/2F0021E8", slot2_lsn=None, standby_lsn="0/2F0021E8"
+    )):
+        cm.main_monitoring_loop(requested_check=True)
+        assert len(cm.replication_slots_cache) == 1
+        assert "test_slot_v1" in cm.replication_slots_cache
+        assert cm.replication_slots_cache["test_slot_v1"] == [repl_slot1_data("0/2F0021E8")]
+
+    # Add the same first slot state twice and the updated second slot, now we should have both, first one should not
+    # be duplicated
+    with patch.object(cm, "_query_cluster_member_state", create_query_cluster_member_state(
+        slot1_lsn="0/2F0021E8", slot2_lsn="0/2F001940", standby_lsn="0/2F0021E8"
+    )):
+        cm.main_monitoring_loop(requested_check=True)
+        assert len(cm.replication_slots_cache) == 2
+        assert "test_slot_v1" in cm.replication_slots_cache
+        assert cm.replication_slots_cache["test_slot_v1"] == [repl_slot1_data("0/2F0021E8")]
+        assert "test_slot_v2" in cm.replication_slots_cache
+        assert cm.replication_slots_cache["test_slot_v2"] == [repl_slot2_data("0/2F001940")]
+
+    # Add 5 more slot states which are much further into the future, keep standby position the same
+    # it should end up in the cache of size 5, so the last state will be removed
+    for lsn in ["0/2F003000", "0/2F003001", "0/2F003002", "0/2F003003", "1/2F003000"]:
+        with patch.object(cm, "_query_cluster_member_state", create_query_cluster_member_state(
+            slot1_lsn=lsn, slot2_lsn="0/2F001940", standby_lsn="0/2F000000"
+        )):
+            cm.main_monitoring_loop(requested_check=True)
+
+    assert len(cm.replication_slots_cache) == 2
+    assert "test_slot_v1" in cm.replication_slots_cache
+    assert len(cm.replication_slots_cache["test_slot_v1"]) == 5
+    # First entry is still the oldest, as standby did not advance yet
+    assert cm.replication_slots_cache["test_slot_v1"][0] == repl_slot1_data("0/2F0021E8")
+    assert "test_slot_v2" in cm.replication_slots_cache
+    assert cm.replication_slots_cache["test_slot_v2"] == [repl_slot2_data("0/2F001940")]
+
+    # Now advance the standby position, so only the latest state remains
+    with patch.object(cm, "_query_cluster_member_state", create_query_cluster_member_state(
+        slot1_lsn="1/2F003000", slot2_lsn="0/2F001940", standby_lsn="1/2F003000"
+    )):
+        cm.main_monitoring_loop(requested_check=True)
+
+    assert len(cm.replication_slots_cache) == 2
+    assert "test_slot_v1" in cm.replication_slots_cache
+    assert cm.replication_slots_cache["test_slot_v1"] == [repl_slot1_data("0/2F003003")]
+    assert "test_slot_v2" in cm.replication_slots_cache
+    assert cm.replication_slots_cache["test_slot_v2"] == [repl_slot2_data("0/2F001940")]

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -6,6 +6,7 @@ Copyright (c) 2016 Ohmu Ltd
 This file is under the Apache License, Version 2.0.
 See the file `LICENSE` for details.
 """
+from pglookout.common import JsonObject
 from pglookout.webserver import WebServer
 from queue import Queue
 import random
@@ -24,12 +25,26 @@ def test_webserver():
     base_url = f"http://127.0.0.1:{http_port}"
     cluster_monitor_check_queue = Queue()
 
-    web = WebServer(config=config, cluster_state=cluster_state, cluster_monitor_check_queue=cluster_monitor_check_queue)
+    overall_state = {
+        "db_nodes": {},
+        "observer_nodes": {},
+        "current_master": "1",
+        "replication_slots_cache": {}
+    }
+
+    def get_overall_state_func() -> JsonObject:
+        return overall_state
+
+    web = WebServer(config=config, cluster_state=cluster_state, cluster_monitor_check_queue=cluster_monitor_check_queue,
+                    get_overall_state_func=get_overall_state_func)
     try:
         web.start()
         time.sleep(1)
         result = requests.get(f"{base_url}/state.json", timeout=5).json()
         assert result == cluster_state
+
+        result = requests.get(f"{base_url}/overall-state.json", timeout=5).json()
+        assert result == overall_state
 
         result = requests.post(f"{base_url}/check", timeout=5)
         assert result.status_code == 204


### PR DESCRIPTION
* Maintain cache of replication slots states
* Expose overall state over HTTP API

Replication slots cache is needed when one wants to re-create replication slots from the master on a promoted standby. It's not possible to use the latest state from the master, as it might be further ahead than a standby, so if standby is lagging behind and failover happens, replication slot with LSN in the future won't be usable. Instead by using this introduced cache one could use older replication slot state for recovery (cache keeps the state which is not newer than the most up-to-date standby), there will potentially be data duplication, but it's still better than not usable slot.