### PR TITLE
Revert "Merge pull request #84 from aiven/alex-repl-slots-states-cache" [BF-1513]

### DIFF
--- a/pglookout/common.py
+++ b/pglookout/common.py
@@ -4,12 +4,8 @@ pglookout - common utility functions
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
-from typing import Any, Dict
-
 import datetime
 import re
-
-JsonObject = Dict[str, Any]
 
 
 def convert_xlog_location_to_offset(wal_location):

--- a/test/test_cluster_monitor.py
+++ b/test/test_cluster_monitor.py
@@ -11,10 +11,8 @@ from mock import patch
 from packaging import version
 from pglookout import statsd
 from pglookout.cluster_monitor import ClusterMonitor
-from pglookout.common import JsonObject
 from psycopg2.extras import RealDictCursor
 from queue import Queue
-from typing import Callable, Optional, Tuple
 
 import base64
 import psycopg2
@@ -69,7 +67,6 @@ def test_main_loop(db):
         failover_decision_queue=failover_decision_queue,
         stats=statsd.StatsClient(host=None),
         is_replication_lag_over_warning_limit=lambda: False,
-        replication_slots_cache={},
     )
     assert cm.last_monitoring_success_time is None
     before = time.monotonic()
@@ -132,7 +129,6 @@ def test_fetch_replication_slot_info(db: TestPG) -> None:
         failover_decision_queue=failover_decision_queue,
         stats=statsd.StatsClient(host=None),
         is_replication_lag_over_warning_limit=lambda: False,
-        replication_slots_cache={},
     )
     cm.main_monitoring_loop(requested_check=True)
 
@@ -150,160 +146,3 @@ def test_fetch_replication_slot_info(db: TestPG) -> None:
             assert b"\0" in base64.b64decode(slot.state_data)
 
             cursor.execute("SELECT pg_drop_replication_slot('testslot1')")
-
-
-def repl_slot1_data(slot_lsn: str) -> JsonObject:
-    return {
-        "slot_name": "test_slot_v1",
-        "plugin": "wal2json",
-        "slot_type": "logical",
-        "database": "defaultdb",
-        "catalog_xmin": "7565",
-        "restart_lsn": "0/2F0021B0",
-        "confirmed_flush_lsn": slot_lsn,
-        "state_data": "oRwFAcg9zQUCAAAAuAAAAHRlc3Rfc2xvdF92MwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdQAAAAAAAAAAAAACNHQAAsCEALwAAAAAAAAAAAAAAAOgh\n"
-        "AC8AAAAA6CEALwAAAAAAd2FsMmpzb24AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-    }
-
-
-def repl_slot2_data(slot_lsn: str) -> JsonObject:
-    return {
-        "slot_name": "test_slot_v2",
-        "plugin": "wal2json",
-        "slot_type": "logical",
-        "database": "defaultdb",
-        "catalog_xmin": "7565",
-        "restart_lsn": "0/2F0021B0",
-        "confirmed_flush_lsn": slot_lsn,
-        "state_data": "oRwFAXYIR6MCAAAAuAAAAHRlc3Rfc2xvdF92MgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdQAAAAAAAAAAAAACNHQAACBkALwAAAAAAAAAAAAAAAEAZ\n"
-        "AC8AAAAAQBkALwAAAAAAdGVzdF9kZWNvZGluZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-    }
-
-
-def create_query_cluster_member_state(
-    slot1_lsn: Optional[str], slot2_lsn: Optional[str], standby_lsn: str
-) -> Callable[[str, Tuple[str, bytes]], JsonObject]:
-    def query_cluster_member_state(instance: str, _: Tuple[str, bytes]) -> JsonObject:
-        # Master
-        if instance == "test1db":
-            return {
-                "fetch_time": "2022-10-13T07:11:07.087062Z",
-                "connection": True,
-                "db_time": "2022-10-13T07:11:07.087648Z",
-                "pg_is_in_recovery": False,
-                "pg_last_xact_replay_timestamp": None,
-                "pg_last_xlog_receive_location": None,
-                "pg_last_xlog_replay_location": "1/E000548",
-                "replication_slots": [
-                    repl_slot1_data(slot1_lsn),
-                    repl_slot2_data(slot2_lsn),
-                ],
-            }
-        return {
-            "fetch_time": "2022-10-13T07:11:07.087439Z",
-            "connection": True,
-            "db_time": "2022-10-13T07:11:07.087604Z",
-            "pg_is_in_recovery": True,
-            "pg_last_xact_replay_timestamp": "2022-10-13T07:11:05.085952Z",
-            "pg_last_xlog_receive_location": standby_lsn,
-            "pg_last_xlog_replay_location": "1/E000548",
-            "replication_time_lag": 2.001652,
-            "min_replication_time_lag": 0.007882,
-        }
-
-    return query_cluster_member_state
-
-
-def test_update_cluster_member_state_replication_slots_cache(db: TestPG) -> None:
-    if version.parse(db.pgver) < version.parse("10"):
-        pytest.skip(f"unsupported pg version: {db.pgver}")
-
-    config = {
-        "remote_conns": {
-            "test1db": db.connection_string("testuser"),
-            "test2db": db.connection_string("otheruser"),
-        },
-        "observers": {"local": "URL"},
-        "poll_observers_on_warning_only": True,
-    }
-    cluster_state = {}
-    observer_state = {}
-
-    def create_alert_file(arg) -> None:
-        raise Exception(arg)
-
-    cluster_monitor_check_queue = Queue()
-    failover_decision_queue = Queue()
-
-    cm = ClusterMonitor(
-        config=config,
-        cluster_state=cluster_state,
-        observer_state=observer_state,
-        create_alert_file=create_alert_file,
-        cluster_monitor_check_queue=cluster_monitor_check_queue,
-        failover_decision_queue=failover_decision_queue,
-        stats=statsd.StatsClient(host=None),
-        is_replication_lag_over_warning_limit=lambda: False,
-        replication_slots_cache={},
-    )
-
-    # Only first slot state should be added, as the second one does not have anything flushed
-    with patch.object(
-        cm,
-        "_query_cluster_member_state",
-        create_query_cluster_member_state(slot1_lsn="0/2F0021E8", slot2_lsn=None, standby_lsn="0/2F0021E8"),
-    ):
-        cm.main_monitoring_loop(requested_check=True)
-        assert len(cm.replication_slots_cache) == 1
-        assert "test_slot_v1" in cm.replication_slots_cache
-        assert cm.replication_slots_cache["test_slot_v1"] == [repl_slot1_data("0/2F0021E8")]
-
-    # Add the same first slot state twice and the updated second slot, now we should have both, first one should not
-    # be duplicated
-    with patch.object(
-        cm,
-        "_query_cluster_member_state",
-        create_query_cluster_member_state(slot1_lsn="0/2F0021E8", slot2_lsn="0/2F001940", standby_lsn="0/2F0021E8"),
-    ):
-        cm.main_monitoring_loop(requested_check=True)
-        assert len(cm.replication_slots_cache) == 2
-        assert "test_slot_v1" in cm.replication_slots_cache
-        assert cm.replication_slots_cache["test_slot_v1"] == [repl_slot1_data("0/2F0021E8")]
-        assert "test_slot_v2" in cm.replication_slots_cache
-        assert cm.replication_slots_cache["test_slot_v2"] == [repl_slot2_data("0/2F001940")]
-
-    # Add 5 more slot states which are much further into the future, keep standby position the same
-    # it should end up in the cache of size 5, so the last state will be removed
-    for lsn in ["0/2F003000", "0/2F003001", "0/2F003002", "0/2F003003", "1/2F003000"]:
-        with patch.object(
-            cm,
-            "_query_cluster_member_state",
-            create_query_cluster_member_state(slot1_lsn=lsn, slot2_lsn="0/2F001940", standby_lsn="0/2F000000"),
-        ):
-            cm.main_monitoring_loop(requested_check=True)
-
-    assert len(cm.replication_slots_cache) == 2
-    assert "test_slot_v1" in cm.replication_slots_cache
-    assert len(cm.replication_slots_cache["test_slot_v1"]) == 5
-    # First entry is still the oldest, as standby did not advance yet
-    assert cm.replication_slots_cache["test_slot_v1"][0] == repl_slot1_data("0/2F0021E8")
-    assert "test_slot_v2" in cm.replication_slots_cache
-    assert cm.replication_slots_cache["test_slot_v2"] == [repl_slot2_data("0/2F001940")]
-
-    # Now advance the standby position, so only the latest state remains
-    with patch.object(
-        cm,
-        "_query_cluster_member_state",
-        create_query_cluster_member_state(slot1_lsn="1/2F003000", slot2_lsn="0/2F001940", standby_lsn="1/2F003000"),
-    ):
-        cm.main_monitoring_loop(requested_check=True)
-
-    assert len(cm.replication_slots_cache) == 2
-    assert "test_slot_v1" in cm.replication_slots_cache
-    assert cm.replication_slots_cache["test_slot_v1"] == [repl_slot1_data("0/2F003003")]
-    assert "test_slot_v2" in cm.replication_slots_cache
-    assert cm.replication_slots_cache["test_slot_v2"] == [repl_slot2_data("0/2F001940")]

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -6,7 +6,6 @@ Copyright (c) 2016 Ohmu Ltd
 This file is under the Apache License, Version 2.0.
 See the file `LICENSE` for details.
 """
-from pglookout.common import JsonObject
 from pglookout.webserver import WebServer
 from queue import Queue
 
@@ -26,30 +25,12 @@ def test_webserver():
     base_url = f"http://127.0.0.1:{http_port}"
     cluster_monitor_check_queue = Queue()
 
-    overall_state = {
-        "db_nodes": {},
-        "observer_nodes": {},
-        "current_master": "1",
-        "replication_slots_cache": {},
-    }
-
-    def get_overall_state_func() -> JsonObject:
-        return overall_state
-
-    web = WebServer(
-        config=config,
-        cluster_state=cluster_state,
-        cluster_monitor_check_queue=cluster_monitor_check_queue,
-        get_overall_state_func=get_overall_state_func,
-    )
+    web = WebServer(config=config, cluster_state=cluster_state, cluster_monitor_check_queue=cluster_monitor_check_queue)
     try:
         web.start()
         time.sleep(1)
         result = requests.get(f"{base_url}/state.json", timeout=5).json()
         assert result == cluster_state
-
-        result = requests.get(f"{base_url}/overall-state.json", timeout=5).json()
-        assert result == overall_state
 
         result = requests.post(f"{base_url}/check", timeout=5)
         assert result.status_code == 204


### PR DESCRIPTION
Revert replication slots caching functionality, there is a more elegant way to sync replication slots from the master to standbys without cache with some help of extra functionality, which needs to be implemented as extension.

This reverts commit d507d1172cae2ec56ddf5a80c004d51f8d1193a0, reversing changes made to 932331ba63725097df624e756cc8364d6d83a3c2.