### PR TITLE
Wait for the webserver in test

### DIFF
--- a/pglookout/webserver.py
+++ b/pglookout/webserver.py
@@ -13,6 +13,7 @@ from socketserver import ThreadingMixIn
 from threading import Thread
 
 import json
+import threading
 
 
 class ThreadedWebServer(ThreadingMixIn, HTTPServer):
@@ -33,6 +34,7 @@ class WebServer(Thread):
         self.port = self.config.get("http_port", 15000)
         self.server = None
         self.log.debug("WebServer initialized with address: %r port: %r", self.address, self.port)
+        self.is_initialized = threading.Event()
 
     def run(self):
         # We bind the port only when we start running
@@ -40,6 +42,7 @@ class WebServer(Thread):
         self.server.cluster_state = self.cluster_state
         self.server.log = self.log
         self.server.cluster_monitor_check_queue = self.cluster_monitor_check_queue
+        self.is_initialized.set()
         self.server.serve_forever()
 
     def close(self):

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -11,7 +11,6 @@ from queue import Queue
 
 import random
 import requests
-import time
 
 
 def test_webserver():
@@ -28,7 +27,9 @@ def test_webserver():
     web = WebServer(config=config, cluster_state=cluster_state, cluster_monitor_check_queue=cluster_monitor_check_queue)
     try:
         web.start()
-        time.sleep(1)
+        # wait for the thread to have started, else we're blocking forever as web.close can't shutdown the thread
+        web.is_initialized.wait(timeout=30.0)
+
         result = requests.get(f"{base_url}/state.json", timeout=5).json()
         assert result == cluster_state
 


### PR DESCRIPTION
If we run into an exception in the main thread we're never terminating, blocking everything.