### PR TITLE
mypy: `pglookout/current-master.py` [BF-1560]

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,4 +3,4 @@
 export PYBUILD_NAME=pglookout
 
 %:
-	dh $@ --with python2 --with systemd --buildsystem=pybuild
+	dh $@ --with python3 --with systemd --buildsystem=pybuild

--- a/pglookout/current_master.py
+++ b/pglookout/current_master.py
@@ -8,7 +8,7 @@ This file is under the Apache License, Version 2.0.
 See the file `LICENSE` for details.
 """
 
-from __future__ import print_function
+from __future__ import annotations
 
 from . import version
 
@@ -19,7 +19,7 @@ import sys
 import time
 
 
-def main(args=None):
+def main(args: list[str] | None = None) -> int:
     if args is None:
         args = sys.argv[1:]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ exclude = [
     'pglookout/__main__.py',
     'pglookout/cluster_monitor.py',
     'pglookout/common.py',
-    'pglookout/current_master.py',
     'pglookout/logutil.py',
     'pglookout/pglookout.py',
     'pglookout/pgutil.py',


### PR DESCRIPTION
Also in this commit:
- removed `python2` leftovers (from pglookout 2.0.0 (2018-10-12))