### PR TITLE
Regenerate recovery information on config reload [BF-1812]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ disable = [
 
 [tool.pylint.'FORMAT']
 max-line-length = 125
-max-module-lines = 1200
+max-module-lines = 1300
 
 [tool.pylint.'REPORTS']
 output-format = 'text'


### PR DESCRIPTION
This should be a no-op in most cases but in certain edge-cases (e.g. when changing a password) it can leave the standby without a possibility to connect to the primary and thus fall behind in replication.