### PR TITLE
Issue #111 High CPU when master missing

### DIFF
--- a/pglookout/cluster_monitor.py
+++ b/pglookout/cluster_monitor.py
@@ -372,6 +372,7 @@ class ClusterMonitor(Thread):
         while self.running:
             requested_check = False
             try:
+                time.sleep(1.0)
                 requested_check = self.cluster_monitor_check_queue.get(timeout=self.config.get("db_poll_interval", 5.0))
             except Empty:
                 pass

--- a/pglookout/pglookout.py
+++ b/pglookout/pglookout.py
@@ -871,6 +871,7 @@ class PgLookout:
                 self.log.exception("Failed to write cluster state")
                 self.stats.unexpected_exception(ex, where="main_loop_writer_cluster_state")
             try:
+                time.sleep(1.0)
                 self.failover_decision_queue.get(timeout=self._get_check_interval())
                 q = self.failover_decision_queue
                 while not q.empty():


### PR DESCRIPTION
resolves #111
Messages keep bouncing between the cluster_monitor thread and the pglookout thread.
Workaround: sleep a second just before the queue gets
