### PR TITLE
Change wait_select default timeout to 10 seconds

### DIFF
--- a/pglookout/cluster_monitor.py
+++ b/pglookout/cluster_monitor.py
@@ -44,7 +44,7 @@ class ReplicationSlot:
     state_data: str
 
 
-def wait_select(conn, timeout=5.0):
+def wait_select(conn, timeout=10.0):
     end_time = time.monotonic() + timeout
     while time.monotonic() < end_time:
         time_left = end_time - time.monotonic()


### PR DESCRIPTION
Default timeout of wait_select was 5 seconds. When a node in google-europe-north1 need to observe a PG in upcloud-sg-sin, will result in PglookoutTimeout.

This commit increase wait_select default timeout to 10 seconds.